### PR TITLE
Add a trailing newline to fix GO 1.20 test compile error

### DIFF
--- a/compare/compare.go
+++ b/compare/compare.go
@@ -52,7 +52,7 @@ func NegateOf[A any](f func(A) bool) func(A) bool {
 	}
 }
 
-//Ternary is equivalent to "expression ? a : b" ternary notation and returns ifTrue if true and ifFalse if false
+// Ternary is equivalent to "expression ? a : b" ternary notation and returns ifTrue if true and ifFalse if false
 func Ternary[A any](boolean bool, ifTrue A, ifFalse A) A {
 	if boolean {
 		return ifTrue


### PR DESCRIPTION
Fixes an "syntax error: unexpected var after top level declaration" error when running 'go test -cover -covermode=atomic ./...' with GO 1.20.

Related to GO issue: https://github.com/golang/go/issues/58370