### PR TITLE
UniqBy, TakeRightWhile, Filter - Optimize and set initial capacities

### DIFF
--- a/slicez/slices.go
+++ b/slicez/slices.go
@@ -253,16 +253,14 @@ func TakeWhile[A any](slice []A, take func(a A) bool) []A {
 
 // TakeRightWhile will produce a new slice containing all elements from the right until the "take" func returns false
 func TakeRightWhile[A any](slice []A, take func(a A) bool) []A {
-	var l = len(slice)
-	var res []A
-	for i := range slice {
-		i = l - i - 1
-		val := slice[i]
-		if !take(val) {
+	idx := len(slice) - 1
+	for ; 0 <= idx; idx-- {
+		if !take(slice[idx]) {
 			break
 		}
-		res = append([]A{val}, res...)
 	}
+	res := make([]A, len(slice)-1-idx)
+	copy(res, slice[idx+1:])
 	return res
 }
 
@@ -376,7 +374,7 @@ func DropRight[A any](slice []A, i int) []A {
 
 // Filter will produce a new slice only containing elements where the "include" function returns true
 func Filter[A any](slice []A, include func(a A) bool) []A {
-	var res []A
+	res := make([]A, 0, len(slice)/2)
 	for _, val := range slice {
 		if include(val) {
 			res = append(res, val)
@@ -647,8 +645,8 @@ func Uniq[A comparable](slice []A) []A {
 
 // UniqBy returns a slice with no duplicate entries using the by function to determine the key
 func UniqBy[A any, B comparable](slice []A, by func(a A) B) []A {
-	var res []A
-	var set = map[B]struct{}{}
+	set := make(map[B]struct{}, len(slice))
+	res := make([]A, 0, len(slice))
 	for _, e := range slice {
 		key := by(e)
 		_, exist := set[key]

--- a/slicez/slices_test.go
+++ b/slicez/slices_test.go
@@ -182,14 +182,33 @@ func TestJoin(t *testing.T) {
 }
 
 func TestTakeRight(t *testing.T) {
-
 	ints := []int{1, 2, 3}
-	exp := []int{2, 3}
-	res := TakeRight(ints, 2)
-	if !reflect.DeepEqual(res, exp) {
-		t.Fail()
-		t.Logf("expected, %v to equal %v\n", res, exp)
+	check := func(res []int, exp []int) {
+		if !reflect.DeepEqual(res, exp) {
+			t.Fail()
+			t.Logf("expected, %v to equal %v\n", res, exp)
+		}
 	}
+	t.Run("take zero", func(t *testing.T) {
+		res := TakeRight(ints, 0)
+		exp := []int{}
+		check(res, exp)
+	})
+	t.Run("take last", func(t *testing.T) {
+		res := TakeRight(ints, 1)
+		exp := []int{3}
+		check(res, exp)
+	})
+	t.Run("take two last", func(t *testing.T) {
+		res := TakeRight(ints, 2)
+		exp := []int{2, 3}
+		check(res, exp)
+	})
+	t.Run("take all", func(t *testing.T) {
+		res := TakeRight(ints, len(ints))
+		check(res, ints)
+	})
+
 }
 
 func TestTakeLeft(t *testing.T) {


### PR DESCRIPTION
This PR optimizes slice functions TakeRightWhile, Filter and UniqBy. We noticed a large amount of time spent in Go's runtime.growslice in our project.  

Benchmarking with `go test -bench=. -count 10 -benchmem` and comparing pre/post code results with `benchstat -ignore .name <file1> <file2>`

See table with results below

|                | sec/op                | B/op                  | allocs/op           |  
|----------------|-----------------------|-----------------------|---------------------|
| TakeRightWhile | 181.151µ ± 21%        | 563.51Ki ± 0%         | 179.000 ± 1%        | 
| With changes   | 5.188µ ± 61%  -97.14% | 12.02Ki ± 0%  -97.87% | 1.000 ± 0%  -99.44% |  
|                |                       |                       |                     |  
| UniqBy         | 911.2µ ± 1%           | 1516.6Ki ± 0%         | 2.222k ± 0%         | 
| With changes   | 453.5µ ± 1%  -50.23%          | 453.5µ ± 1%  -50.23%          | 2.123k ± 0%  -4.46% |  
|                |                       |                       |                     |   |   |   |   |   |   |
| Filter         | 406.7µ ± 3%           | 1120.7Ki ± 0%         | 24.000 ± 0%         |
| With changes   | 120.7µ ± 3%  -70.31%  | 280.6Ki ± 0%  -74.96% | 4.000 ± 0%  -83.33% |
|                |                       |                       |                     |  




